### PR TITLE
Replace torch._six.string_classes by str

### DIFF
--- a/datasets/vision.py
+++ b/datasets/vision.py
@@ -7,7 +7,7 @@ class VisionDataset(data.Dataset):
     _repr_indent = 4
 
     def __init__(self, root, transforms=None, transform=None, target_transform=None):
-        if isinstance(root, torch._six.string_classes):
+        if isinstance(root, str):
             root = os.path.expanduser(root)
         self.root = root
         


### PR DESCRIPTION
According to https://github.com/pytorch/pytorch/pull/97863 torch._six has been removed. I propose the following modification to avoid the error "module 'torch' has no attribute '_six'". This solution is also suggested in other projects: https://github.com/NVIDIA/apex/issues/1724.